### PR TITLE
Ensure byte timeseries plot legends exist

### DIFF
--- a/tsndt/src/context/ethernet.rs
+++ b/tsndt/src/context/ethernet.rs
@@ -546,7 +546,9 @@ impl EthernetView {
                     .style(Style::default().fg(DISABLED_COLOR))
                     .labels(y_labels)
                     .bounds(self.byte_count_y_bounds),
-            );
+            )
+            .hidden_legend_constraints((Constraint::Min(0), Constraint::Min(0)))
+            .legend_position(Some(LegendPosition::TopLeft));
 
         frame.render_widget(chart, area);
     }

--- a/tsndt/src/context/network_interface.rs
+++ b/tsndt/src/context/network_interface.rs
@@ -717,7 +717,9 @@ impl NetworkInterfaceView {
                     .style(Style::default().fg(DISABLED_COLOR))
                     .labels(y_labels)
                     .bounds(self.byte_count_y_bounds),
-            );
+            )
+            .hidden_legend_constraints((Constraint::Min(0), Constraint::Min(0)))
+            .legend_position(Some(LegendPosition::TopLeft));
 
         frame.render_widget(chart, area);
     }


### PR DESCRIPTION
Make sure they are always present and ensure they are placed in the upper left of the plots.

Addresses #20